### PR TITLE
Switch the access method to the portmidi submodule to https from ssh,…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://git.assembla.com/portaudio.git
 [submodule "q_io/external/portmidi"]
 	path = q_io/external/portmidi
-	url = git@github.com:cycfi/portmidi.git
+	url = https://github.com/cycfi/portmidi.git


### PR DESCRIPTION
… to be able to clone it without an ssh key on the appveyor CI system.