### PR TITLE
Simple seek support for q_io wav_readers

### DIFF
--- a/q_io/include/q_io/audio_file.hpp
+++ b/q_io/include/q_io/audio_file.hpp
@@ -49,6 +49,7 @@ namespace cycfi::q
 
       std::size_t    length() const;
       std::size_t    read(float* data, std::uint32_t len);
+      void           restart();
 
                      template <typename Buffer>
       std::size_t    read(Buffer& buffer);
@@ -73,6 +74,7 @@ namespace cycfi::q
       using wav_reader::length;
       using wav_reader::sps;
       using wav_reader::num_channels;
+      using wav_reader::restart;
 
       range const    operator()();
 

--- a/q_io/include/q_io/audio_file.hpp
+++ b/q_io/include/q_io/audio_file.hpp
@@ -49,7 +49,8 @@ namespace cycfi::q
 
       std::size_t    length() const;
       std::size_t    read(float* data, std::uint32_t len);
-      void           restart();
+      bool           restart();
+      bool           seek(std::uint64_t target);
 
                      template <typename Buffer>
       std::size_t    read(Buffer& buffer);

--- a/q_io/src/audio_file.cpp
+++ b/q_io/src/audio_file.cpp
@@ -62,6 +62,12 @@ namespace cycfi::q
       return 0;
    }
 
+	
+   void wav_reader::restart() {
+       if (_wav)
+           drwav_seek_to_first_sample(_wav);
+   }
+
    wav_writer::wav_writer(
       char const* filename
     , std::uint32_t num_channels, std::uint32_t sps)

--- a/q_io/src/audio_file.cpp
+++ b/q_io/src/audio_file.cpp
@@ -63,9 +63,16 @@ namespace cycfi::q
    }
 
 	
-   void wav_reader::restart() {
+   bool wav_reader::restart()
+   {
        if (_wav)
-           drwav_seek_to_first_sample(_wav);
+           return drwav_seek_to_first_sample(_wav);
+   }
+
+   bool wav_reader::seek(std::uint64_t target)
+   {
+        if (_wav)
+            return drwav_seek_to_sample(_wav, target);
    }
 
    wav_writer::wav_writer(


### PR DESCRIPTION
Just a really small change I found useful. Allows for restarting or seeking to an arbitrary sample with a q_io wav_reader (and therefore also wav_memory).

Right now there's not really a way to seek backwards so this should prove useful.

Tested in my own project and seems to work perfectly well (after all, it basically just maps to dr_wav's existing functions).