### PR TITLE
Add position() function on wav_reader, also make wav_memory::seek public

### DIFF
--- a/q_io/include/q_io/audio_file.hpp
+++ b/q_io/include/q_io/audio_file.hpp
@@ -48,6 +48,7 @@ namespace cycfi::q
       wav_reader(char const* filename);
 
       std::size_t    length() const;
+      std::size_t    position();
       std::size_t    read(float* data, std::uint32_t len);
       bool           restart();
       bool           seek(std::uint64_t target);
@@ -73,6 +74,7 @@ namespace cycfi::q
 
       using wav_reader::operator bool;
       using wav_reader::length;
+      using wav_reader::position;
       using wav_reader::sps;
       using wav_reader::num_channels;
       using wav_reader::restart;

--- a/q_io/include/q_io/audio_file.hpp
+++ b/q_io/include/q_io/audio_file.hpp
@@ -78,6 +78,7 @@ namespace cycfi::q
       using wav_reader::sps;
       using wav_reader::num_channels;
       using wav_reader::restart;
+      using wav_reader::seek;
 
       range const    operator()();
 

--- a/q_io/src/audio_file.cpp
+++ b/q_io/src/audio_file.cpp
@@ -73,7 +73,7 @@ namespace cycfi::q
    std::size_t wav_reader::position()
    {
        if (_wav)
-           return _wav->totalSampleCount - (_wav->bytesRemaining / sizeof(float));
+           return _wav->totalSampleCount - (_wav->bytesRemaining / _wav->bytesPerSample);
        return 0;
    }
 

--- a/q_io/src/audio_file.cpp
+++ b/q_io/src/audio_file.cpp
@@ -41,7 +41,7 @@ namespace cycfi::q
       if (_wav)
          return _wav->channels;
       return 0;
-}
+   }
 
    wav_reader::wav_reader(char const* filename)
    {
@@ -67,6 +67,14 @@ namespace cycfi::q
    {
        if (_wav)
            return drwav_seek_to_first_sample(_wav);
+       return false;
+   }
+
+   std::size_t wav_reader::position()
+   {
+       if (_wav)
+           return _wav->totalSampleCount - (_wav->bytesRemaining / sizeof(float));
+       return 0;
    }
 
    bool wav_reader::seek(std::uint64_t target)


### PR DESCRIPTION
Allows getting the current sample we're playing from a wav_memory or any other wav_reader. Ties into my previous PR (restart support), as knowing where you are is helpful for seeking :P. Also I noticed that wav_memory didn't have seek as public. That was a mistake on my part, fixed that.