### PR TITLE
fix: add missing include

### DIFF
--- a/q_lib/include/q/utility/zero_crossing_collector.hpp
+++ b/q_lib/include/q/utility/zero_crossing_collector.hpp
@@ -10,6 +10,7 @@
 #include <q/utility/bitset.hpp>
 #include <q/utility/ring_buffer.hpp>
 #include <q/support/decibel.hpp>
+#include <q/support/frequency.hpp>
 #include <infra/assert.hpp>
 #include <cmath>
 


### PR DESCRIPTION
When only including:
```c++
#include <q/pitch/period_detector.hpp>
```
I'm getting the error
```
In file included from /home/louis/Documents/repos/harmonizer/third_party/Q/q_lib/include/q/pitch/period_detector.hpp:10,
                 from /home/louis/Documents/repos/harmonizer/src/pitch_detection.cc:3:
/home/louis/Documents/repos/harmonizer/third_party/Q/q_lib/include/q/utility/zero_crossing_collector.hpp: In constructor ‘cycfi::q::zero_crossing_collector::zero_crossing_collector(cycfi::q::decibel, cycfi::duration, uint32_t)’:
/home/louis/Documents/repos/harmonizer/third_party/Q/q_lib/include/q/utility/zero_crossing_collector.hpp:132:67: error: could not convert ‘window’ from ‘cycfi::duration’ {aka ‘std::chrono::duration<double>’} to ‘cycfi::q::decibel’
  132 |     : zero_crossing_collector{hysteresis, std::uint32_t(as_double(window) * sps)}
      |                                                                   ^~~~~~
      |                                                                   |
      |                                                                   cycfi::duration {aka std::chrono::duration<double>}
/home/louis/Documents/repos/harmonizer/third_party/Q/q_lib/include/q/utility/zero_crossing_collector.hpp:132:81: error: no matching function for call to ‘cycfi::q::zero_crossing_collector::zero_crossing_collector(<brace-enclosed initializer list>)’
  132 |     : zero_crossing_collector{hysteresis, std::uint32_t(as_double(window) * sps)}
      |                                                                                 ^
```
Adding the missing include fixes that.