### PR TITLE
Fix type of parameter in dc_block::operator= function

### DIFF
--- a/docs/modules/ROOT/pages/reference/misc/dc_block.adoc
+++ b/docs/modules/ROOT/pages/reference/misc/dc_block.adoc
@@ -23,7 +23,7 @@ struct dc_block
 
    float       operator()(float s);
    float       operator()() const;
-   dc_block&   operator=(bool y_);
+   dc_block&   operator=(float y_);
    void        cutoff(frequency f, float sps);
 };
 ```

--- a/q_lib/include/q/fx/dc_block.hpp
+++ b/q_lib/include/q/fx/dc_block.hpp
@@ -50,7 +50,7 @@ namespace cycfi::q
       return y;
    }
 
-   inline dc_block& dc_block::operator=(bool y_)
+   inline dc_block& dc_block::operator=(float y_)
    {
       y = y_;
       return *this;

--- a/q_lib/include/q/fx/dc_block.hpp
+++ b/q_lib/include/q/fx/dc_block.hpp
@@ -23,7 +23,7 @@ namespace cycfi::q
 
       float       operator()(float s);
       float       operator()() const;
-      dc_block&   operator=(bool y_);
+      dc_block&   operator=(float y_);
       void        cutoff(frequency f, float sps);
 
       float _pole;      // pole


### PR DESCRIPTION
This pull request addresses a type mismatch issue in the dc_block::operator= function.

In the current implementation, the operator= function is declared to take a bool parameter. However it should accept a float instead. 

Change the bool parameter type in dc_block::operator= to float.