### PR TITLE
fix missing "inline" in dynamic.hpp for android ndk-build

### DIFF
--- a/q_lib/include/q/fx/dynamic.hpp
+++ b/q_lib/include/q/fx/dynamic.hpp
@@ -188,7 +188,7 @@ namespace cycfi::q
       }
    }
 
-   void soft_knee_compressor::threshold(decibel val)
+   inline void soft_knee_compressor::threshold(decibel val)
    {
       _threshold = val;
       _lower = _threshold - (_width * 0.5);


### PR DESCRIPTION
Fixes android ndk-build "duplicate symbol" error.

"inline" may not have been added on purpose or accidentally. I am not expert with this (c++17). But seems like fixing android ndk build while don't broke Windows build.

It should be evaluated by a specialist before commit.

Error message in ndk-build without "inline":

```
ld: error: duplicate symbol: cycfi::q::soft_knee_compressor::threshold(cycfi::q::decibel)
>>> defined at dynamic.hpp:192 (./include\q/fx\dynamic.hpp:192)
```