### PR TITLE
v1.0: gcc & clang/libc++ build

### DIFF
--- a/q_io/CMakeLists.txt
+++ b/q_io/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(libqio
    libq
    cycfi::infra
    portmidi
-   PortAudio
+   portaudio
 )
 
 if (APPLE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ project(q_test)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
       OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}-ftemplate-backtrace-limit=0")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-backtrace-limit=0")
 endif()
 
 set(APP_SOURCES


### PR DESCRIPTION
Hello,

Thank you for your work on the q library.

When trying to build the _v1.0_release_ tag on Linux with gcc and clang + libc++, I ran into the problems described in the commits:

- gcc and clang with libc++: portaudio.h not found
- clang with libc++: unrecognized CMAKE_CXX_FLAGS (I ran cmake with -DCMAKE_CXX_FLAGS="-stdlib=libc++"  and  -DCMAKE_CXX_COMPILER=clang++ )

The two minor commits in this pull request solved these problems.