### PR TITLE
Provide unit::unit_type for concepts

### DIFF
--- a/q_lib/include/q/support/unit.hpp
+++ b/q_lib/include/q/support/unit.hpp
@@ -60,6 +60,7 @@ namespace cycfi::q
    {
       using derived_type = Derived;
       using value_type = T;
+      using unit_type = void;
                                     // Temporary constructor. This is not
                                     // marked deprecated because we will use
                                     // this for now.


### PR DESCRIPTION
Fixes Clang 22 errors of the type:

    q/q_lib/include/q/support/unit.hpp:16:51: error: no type named 'unit_type' in 'cycfi::q::unit<T, Derived>'
       16 |       concept SameUnit = std::same_as<typename A::unit_type, typename B::unit_type>;
          |                                       ~~~~~~~~~~~~^~~~~~~~~
    q/q_lib/include/q/support/unit.hpp:93:87: note: while substituting into concept arguments here; substitution failures not allowed in concept arguments
       93 |                                     template <typename U> requires concepts::SameUnit<unit, U>
          |                                                                                       ^~~~
    q/q_lib/include/q/support/phase.hpp:167:14: note: while checking constraint satisfaction for template 'operator+=<phase>' required here
      167 |       _phase += _step;
          |              ^~
    q/q_lib/include/q/support/phase.hpp:167:14: note: while substituting deduced template arguments into function template 'operator+=' [with U = phase]
