### PR TITLE
ci: pin Windows runner to windows-2022 (VS2022)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,11 @@ jobs:
       matrix:
         config:
         - name: "Windows Latest MSVC"
-          os: windows-latest
+          # Pinned to windows-2022 (VS2022). windows-latest now resolves to the
+          # windows-2025-vs2026 image (VS2026), which has no vcvars64.bat at the
+          # hardcoded VS2022 path below, so the MSVC environment never loads and
+          # CMake fails to find cl at configure time.
+          os: windows-2022
           cc: "cl"
           cxx: "cl"
           environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"


### PR DESCRIPTION
## Problem

Windows CI on `master` is failing at the **Configure** step (Ubuntu/GCC and macOS/Clang pass build + test). It dies *before* compiling any source:

```
Could not find the compiler specified in the environment variable CC: cl.
CMAKE_C_COMPILER not set, after EnableLanguage
```

Root cause: `windows-latest` now resolves to the **`windows-2025-vs2026`** image (VS 2026). The workflow loads the MSVC environment from a hardcoded VS2022 path:

```
C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat
```

That path doesn't exist on the VS2026 image (the log shows *"The system cannot find the path specified"*), so `vcvars64.bat` never runs, `cl` is never put on `PATH`, and CMake can't find the compiler. This is an image-migration breakage, unrelated to the code in the triggering commit.

## Fix

Pin the MSVC job to **`windows-2022`**, which still ships VS2022 at the hardcoded path — restoring the exact environment that last passed. Keeps us on VS2022 for now; a follow-up can make the vcvars lookup version-independent (e.g. via `vswhere`) so we can return to `windows-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)