### PR TITLE
Fix dispatch() dropping system common/real-time MIDI messages

### DIFF
--- a/q_lib/include/q/support/midi_processor.hpp
+++ b/q_lib/include/q/support/midi_processor.hpp
@@ -36,7 +36,19 @@ namespace cycfi::q::midi_1_0
    requires concepts::midi_1_0::Processor<P>
    inline void dispatch(raw_message msg, std::size_t time, P&& proc)
    {
-      switch (msg.data & 0xF0) // status
+      // Channel voice messages (0x80-0xEF) encode the channel number in
+      // the low nibble, so only the high nibble is significant. System
+      // common and system real-time messages (0xF0-0xFF), on the other
+      // hand, occupy the entire status byte -- there is no channel to
+      // mask off. Masking those with 0xF0 would collapse all of them to
+      // 0xF0, none of which match any case below (see status::sysex,
+      // 0xF0, which is handled elsewhere), silently dropping every
+      // system common / real-time message.
+      auto const status_byte = msg.data & 0xFF;
+      auto const status_ = (status_byte < status::sysex)?
+         (status_byte & 0xF0) : status_byte;
+
+      switch (status_) // status
       {
          case status::note_off:
             proc(note_off{msg}, time);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(APP_SOURCES
    delay.cpp
    grain.cpp
    interpolation.cpp
+   midi_processor.cpp
    ring_buffer.cpp
    sin.cpp
 
@@ -122,6 +123,7 @@ add_test(NAME test_interpolation COMMAND test_interpolation)
 add_test(NAME test_ring_buffer COMMAND test_ring_buffer)
 add_test(NAME test_delay COMMAND test_delay)
 add_test(NAME test_grain COMMAND test_grain)
+add_test(NAME test_midi_processor COMMAND test_midi_processor)
 add_test(NAME test_best_lag COMMAND test_best_lag)
 add_test(NAME test_moving_sum COMMAND test_moving_sum)
 add_test(NAME test_pitch COMMAND test_pitch)

--- a/test/midi_processor.cpp
+++ b/test/midi_processor.cpp
@@ -1,0 +1,181 @@
+/*=============================================================================
+   Copyright (c) 2014-2026 Joel de Guzman. All rights reserved.
+
+   Distributed under the Boost Software License, Version 1.0.
+   [ https://www.boost.org/LICENSE_1_0.txt ]
+=============================================================================*/
+#define CATCH_CONFIG_MAIN
+#include <infra/catch.hpp>
+#include <q/support/midi_processor.hpp>
+
+namespace q = cycfi::q;
+namespace midi = q::midi_1_0;
+
+namespace
+{
+   enum class event_kind
+   {
+      none,
+      base,
+      note_on,
+      song_position,
+      song_select,
+      tune_request,
+      timing_tick,
+      start,
+      continue_,
+      stop,
+      active_sensing,
+      reset
+   };
+
+   struct recording_processor
+   {
+      event_kind kind = event_kind::none;
+      std::size_t time = 0;
+      std::uint8_t channel = 0;
+      std::uint8_t key = 0;
+      std::uint8_t velocity = 0;
+      std::uint16_t position = 0;
+      std::uint8_t song_number = 0;
+
+      void operator()(midi::message_base const&, std::size_t t)
+      {
+         kind = event_kind::base;
+         time = t;
+      }
+
+      void operator()(midi::note_on const& msg, std::size_t t)
+      {
+         kind = event_kind::note_on;
+         time = t;
+         channel = msg.channel();
+         key = msg.key();
+         velocity = msg.velocity();
+      }
+
+      void operator()(midi::song_position const& msg, std::size_t t)
+      {
+         kind = event_kind::song_position;
+         time = t;
+         position = msg.position();
+      }
+
+      void operator()(midi::song_select const& msg, std::size_t t)
+      {
+         kind = event_kind::song_select;
+         time = t;
+         song_number = msg.song_number();
+      }
+
+      void operator()(midi::tune_request const&, std::size_t t)    { kind = event_kind::tune_request; time = t; }
+      void operator()(midi::timing_tick const&, std::size_t t)     { kind = event_kind::timing_tick; time = t; }
+      void operator()(midi::start const&, std::size_t t)           { kind = event_kind::start; time = t; }
+      void operator()(midi::continue_ const&, std::size_t t)       { kind = event_kind::continue_; time = t; }
+      void operator()(midi::stop const&, std::size_t t)            { kind = event_kind::stop; time = t; }
+      void operator()(midi::active_sensing const&, std::size_t t)  { kind = event_kind::active_sensing; time = t; }
+      void operator()(midi::reset const&, std::size_t t)           { kind = event_kind::reset; time = t; }
+   };
+
+   template <typename Message>
+   midi::raw_message to_raw(Message const& msg)
+   {
+      std::uint32_t data = 0;
+      for (int i = 0; i != Message::size; ++i)
+         data |= std::uint32_t(msg.data[i]) << (i * 8);
+      return {data};
+   }
+}
+
+TEST_CASE("midi dispatch: system common and real-time messages keep their full status byte")
+{
+   constexpr std::size_t time = 123;
+
+   SECTION("song_position")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::song_position{0x12, 0x34}), time, proc);
+      CHECK(proc.kind == event_kind::song_position);
+      CHECK(proc.time == time);
+      CHECK(proc.position == 0x1A12);
+   }
+
+   SECTION("song_select")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::song_select{0x45}), time, proc);
+      CHECK(proc.kind == event_kind::song_select);
+      CHECK(proc.time == time);
+      CHECK(proc.song_number == 0x45);
+   }
+
+   SECTION("tune_request")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::tune_request{}), time, proc);
+      CHECK(proc.kind == event_kind::tune_request);
+      CHECK(proc.time == time);
+   }
+
+   SECTION("timing_tick")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::timing_tick{}), time, proc);
+      CHECK(proc.kind == event_kind::timing_tick);
+      CHECK(proc.time == time);
+   }
+
+   SECTION("start")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::start{}), time, proc);
+      CHECK(proc.kind == event_kind::start);
+      CHECK(proc.time == time);
+   }
+
+   SECTION("continue")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::continue_{}), time, proc);
+      CHECK(proc.kind == event_kind::continue_);
+      CHECK(proc.time == time);
+   }
+
+   SECTION("stop")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::stop{}), time, proc);
+      CHECK(proc.kind == event_kind::stop);
+      CHECK(proc.time == time);
+   }
+
+   SECTION("active_sensing")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::active_sensing{}), time, proc);
+      CHECK(proc.kind == event_kind::active_sensing);
+      CHECK(proc.time == time);
+   }
+
+   SECTION("reset")
+   {
+      recording_processor proc;
+      midi::dispatch(to_raw(midi::reset{}), time, proc);
+      CHECK(proc.kind == event_kind::reset);
+      CHECK(proc.time == time);
+   }
+}
+
+TEST_CASE("midi dispatch: channel voice messages still mask off the channel nibble")
+{
+   recording_processor proc;
+   constexpr std::size_t time = 77;
+
+   midi::dispatch(to_raw(midi::note_on{9, 64, 127}), time, proc);
+
+   CHECK(proc.kind == event_kind::note_on);
+   CHECK(proc.time == time);
+   CHECK(proc.channel == 9);
+   CHECK(proc.key == 64);
+   CHECK(proc.velocity == 127);
+}


### PR DESCRIPTION
## Problem

`midi_1_0::dispatch()` in `q_lib/include/q/support/midi_processor.hpp` masks the incoming status byte with `0xF0` before the `switch`:

```cpp
switch (msg.data & 0xF0) // status
```

This is correct for channel voice messages (`0x80`-`0xEF`): the low nibble holds the channel number, so only the high nibble should select the message type, and note_off/note_on/etc. dispatch correctly on every channel.

It is wrong for system common / system real-time messages (`0xF0`-`0xFF`): these occupy the *entire* status byte and don't have a channel nibble at all. `song_position` (`0xF2`), `song_select` (`0xF3`), `tune_request` (`0xF6`), `timing_tick` (`0xF8`), `start` (`0xFA`), `continue_` (`0xFB`), `stop` (`0xFC`), `active_sensing` (`0xFE`) and `reset` (`0xFF`) all collapse to `0xF0` once masked, which none of their `case` labels equal (the labels are the real, unmasked byte values from `midi_messages.hpp`). So the `switch` silently takes no branch for any of these nine message types — the processor's overload is never invoked, unconditionally, for all of them.

This looks like an unintended side effect of the fix for #22 ("midi processor dispatch() not catching notes on channels other than 0"), which introduced this same `0xF0` mask in `86685e26` back in 2021 to fix channel voice dispatch, without accounting for the status bytes that carry no channel nibble.

Practical impact: any consumer of `dispatch()` that overloads `operator()` for MIDI clock (`timing_tick`), transport (`start`/`continue_`/`stop`), `active_sensing` (connection keep-alive), `tune_request`, or song position/select never receives those events, with no error or indication anything is wrong.

## Fix

Only mask off the channel nibble for status bytes below `sysex` (`0xF0`); use bytes at or above `sysex` as-is, since that's exactly how their `case` labels are already spelled out:

```cpp
auto const status_byte = msg.data & 0xFF;
auto const status_ = (status_byte < status::sysex)?
   (status_byte & 0xF0) : status_byte;

switch (status_) // status
```

Channel voice dispatch (including on channels other than 0, i.e. the original #22 fix) is unaffected. `sysex`/`sysex_end`, which have no `case` in this `switch` and are handled elsewhere, are unaffected too.

## Verification

`midi_processor.hpp` has no unit test coverage (`test/CMakeLists.txt` builds no MIDI test) and the only example (`example/midi_monitor/midi_monitor.cpp`) only overloads channel-voice callbacks, so this has apparently gone unnoticed since the file was added.

I verified with a standalone program (g++ 15.2, `-std=c++20`) against the unpatched header that `dispatch()` never invokes the processor's overload for any of the nine system common/real-time message types, while channel voice messages (e.g. `note_on`) dispatch correctly. After applying this fix, all nine now dispatch as expected. I also re-checked, with the fix applied, that all seven channel voice message types still dispatch correctly on every channel 0-15, and that `sysex`/`sysex_end` still fall through unhandled exactly as before (no regression there).